### PR TITLE
Guard against 'undefined'

### DIFF
--- a/src/helpers/fetchAllData.js
+++ b/src/helpers/fetchAllData.js
@@ -2,6 +2,7 @@
 function fetchAllData(components, getState, dispatch, location, params, deferred) {
   const methodName = deferred ? 'fetchDataDeferred' : 'fetchData';
   return components
+    .filter((component) => !!component) // Weed out 'undefined' routes
     .filter((component) => component[methodName]) // only look at ones with a static fetchData()
     .map((component) => component[methodName])    // pull out fetch data methods
     .map(fetchData =>


### PR DESCRIPTION
Not sure why I didn't experience this before with the old router. I have a router like this, with empty Route wrapper: 

```
<Route>
 {_DEV_ && <Route ...devRoute/>}
<Route to="/" component={App}/>
</Route>
```
